### PR TITLE
Fix programs command table formatting and improve output readability

### DIFF
--- a/internal/commands/programs/programs.go
+++ b/internal/commands/programs/programs.go
@@ -77,11 +77,12 @@ var listCmd = &cobra.Command{
 			switch cfg.Output.Format {
 			case "json":
 				formatter = output.NewJSONFormatter(nil)
+				return formatter.Format(*schedules)
 			default:
 				formatter = output.NewTableFormatter(nil, cfg.Output.NoHeader)
+				// Custom formatting for Schedules - flatten to show programs with channel info
+				return formatSchedulesAsTable(*schedules, formatter)
 			}
-
-			return formatter.Format(*schedules)
 		}
 
 		schedules, err := client.GetSchedules(params)
@@ -93,11 +94,12 @@ var listCmd = &cobra.Command{
 		switch cfg.Output.Format {
 		case "json":
 			formatter = output.NewJSONFormatter(nil)
+			return formatter.Format(*schedules)
 		default:
 			formatter = output.NewTableFormatter(nil, cfg.Output.NoHeader)
+			// Custom formatting for Schedules - flatten to show programs with channel info
+			return formatSchedulesAsTable(*schedules, formatter)
 		}
-
-		return formatter.Format(*schedules)
 	},
 }
 
@@ -125,11 +127,12 @@ var currentCmd = &cobra.Command{
 		switch cfg.Output.Format {
 		case "json":
 			formatter = output.NewJSONFormatter(nil)
+			return formatter.Format(*schedules)
 		default:
 			formatter = output.NewTableFormatter(nil, cfg.Output.NoHeader)
+			// Custom formatting for Schedules - flatten to show programs with channel info
+			return formatSchedulesAsTable(*schedules, formatter)
 		}
-
-		return formatter.Format(*schedules)
 	},
 }
 
@@ -200,4 +203,57 @@ func init() {
 	programsCmd.AddCommand(currentCmd)
 	programsCmd.AddCommand(searchCmd)
 	root.AddCommand(programsCmd)
+}
+
+// formatSchedulesAsTable formats schedule data in a user-friendly table format
+func formatSchedulesAsTable(schedules epgstation.Schedules, formatter output.Formatter) error {
+	if len(schedules) == 0 {
+		fmt.Println("No programs found")
+		return nil
+	}
+
+	// Create a flat list of programs with channel information
+	type ProgramWithChannel struct {
+		ChannelName   string
+		ChannelType   string
+		ProgramName   string
+		StartTime     string
+		EndTime       string
+		Description   string
+	}
+
+	var programs []ProgramWithChannel
+	for _, schedule := range schedules {
+		channelName := schedule.Channel.Name
+		
+		for _, program := range schedule.Programs {
+			startTime := formatUnixTime(int64(program.StartAt))
+			endTime := formatUnixTime(int64(program.EndAt))
+			
+			description := ""
+			if program.Description != nil {
+				description = *program.Description
+				if len(description) > 50 {
+					description = description[:50] + "..."
+				}
+			}
+			
+			programs = append(programs, ProgramWithChannel{
+				ChannelName:   channelName,
+				ChannelType:   string(schedule.Channel.ChannelType),
+				ProgramName:   program.Name,
+				StartTime:     startTime,
+				EndTime:       endTime,
+				Description:   description,
+			})
+		}
+	}
+
+	return formatter.Format(programs)
+}
+
+// formatUnixTime converts Unix timestamp (in milliseconds) to readable time
+func formatUnixTime(unixTimeMS int64) string {
+	t := time.Unix(unixTimeMS/1000, 0)
+	return t.Format("15:04")
 }

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -202,7 +202,19 @@ func (f *TableFormatter) formatValue(v reflect.Value) string {
 			return ""
 		}
 		return fmt.Sprintf("[%d items]", v.Len())
+	case reflect.Struct:
+		// For nested structs, show a summary instead of full structure
+		typeName := v.Type().Name()
+		if typeName == "" {
+			typeName = "struct"
+		}
+		return fmt.Sprintf("<%s>", typeName)
 	default:
-		return fmt.Sprintf("%v", v.Interface())
+		// Avoid showing memory addresses and internal representations
+		typeName := v.Type().Name()
+		if typeName != "" {
+			return fmt.Sprintf("<%s>", typeName)
+		}
+		return fmt.Sprintf("<%s>", v.Type().String())
 	}
 }


### PR DESCRIPTION
## Summary

- Fixed programs current command showing Go struct internals instead of readable program data
- Improved table formatter to handle complex nested data structures properly  
- Added custom formatting for schedule data with channel information

## Key Changes

### Programs Command Improvements
- **Custom Schedule Formatting**: Added `formatSchedulesAsTable()` function that flattens nested schedule data into readable table format
- **Time Display**: Added `formatUnixTime()` helper to convert Unix timestamps to HH:MM format for better readability
- **Description Handling**: Truncate long program descriptions to 50 characters for clean table display
- **Channel Information**: Include channel name and type alongside program details

### Table Formatter Enhancements  
- **Nested Struct Handling**: Improved handling of complex data structures to show type names instead of memory addresses
- **Clean Output**: Avoid displaying Go's internal struct representations in table format
- **Consistent Formatting**: Ensure all data types display appropriately in table format

## Testing

✅ **Tested Commands:**
- `programs current` - Now displays clean table with channel names, program names, times, and descriptions
- `programs search` - Works correctly with improved formatting
- `channels list/show` - Continues to work properly  
- `recordings list/status` - Functions correctly
- **JSON Output** - Unchanged and works for all commands for automation scripts

✅ **Test Server**: Verified against EPGStation server at `http://popplio.foxhound-kelvin.ts.net:8888`

## Related Tasks

Addresses output formatting issues identified during comprehensive CLI testing. Maintains backward compatibility while significantly improving user experience.

## Other

- No breaking changes to API or command interface
- JSON output preserved for automation compatibility
- All existing flags and options continue to work